### PR TITLE
Fix error int64_t was not declared

### DIFF
--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
The <cstdint> header should be declared to use int64_t type based on https://www.cplusplus.com/reference/cstdint/ . 
This also fix error when compile on Alpine Linux.